### PR TITLE
feat: hpb_unpack_for_steam

### DIFF
--- a/hpb/hpb_unpack_for_steam.py
+++ b/hpb/hpb_unpack_for_steam.py
@@ -1,0 +1,38 @@
+import struct
+from zlib import crc32
+from pathlib import Path
+import sys
+
+# Based on https://github.com/YuriSizuku/GalgameReverse/blob/master/project/hunex/src/hunex_hpb.py
+# modded from https://gist.github.com/kjy00302/34461f7ced79be7c48e3d46ae94f047b
+
+packname = sys.argv[1]
+
+f = open(f'{packname}.hph', 'rb')
+data_f = open(f'{packname}.hpb', 'rb')
+
+magic, version, count, size, nameoffset = struct.unpack('<5I12x', f.read(32))
+assert magic == int.from_bytes(b'HPAC', 'little')
+
+offset = f.tell()
+f.seek(nameoffset, 0)
+paths = list(map(lambda x: x.decode(), f.read().split(b'\0')[:count]))
+f.seek(offset, 0)
+
+print(f'filesize: {size}, itemcnt: {count}')
+
+for i in range(count):
+    data = f.read(32)
+    # TODO: QIQI or I4xII4xI?
+    # item = struct.unpack('<Q4xI4xI8x', data) 会报越界错误，如果用以下写法则正常
+    item = struct.Struct("<Q4xI4xI8x")
+    itemoffset, itemsize, itemcrc = item.unpack(data)
+    print(f'offset:{itemoffset} size:{itemsize} crc:{itemcrc:08x} -> {paths[i]}')
+    # if itemsize == 0: continue
+    data_f.seek(itemoffset, 0)
+    itemdata = data_f.read(itemsize)
+    assert itemcrc == crc32(itemdata)
+    p = (Path(f'{packname}_out') / (f"{i:03d}."+paths[i].replace('/', '__'))).resolve()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open('wb') as item_f:
+        item_f.write(itemdata)


### PR DESCRIPTION
在尝试对steam版的hpb资源运行`hpb_unpack.py`时会出现如下的报错情况：
```
filesize: 3968, itemcnt: 83
offset:0 size:0 crc:00000000 -> SYSTEMSE_START
offset:64 size:6997021418059061 crc:7b7c18dc -> SYSSE
Traceback (most recent call last):
  File "D:\Develop\GALReverse\hunex_script-master\hpb\hpb_unpack.py", line 32, in <module>
    itemdata = data_f.read(itemsize)
               ^^^^^^^^^^^^^^^^^^^^^
MemoryError
```
推测是steam版（或者也适用于NS正式版）的文件结构与之前的NS试玩版文件结构产生了变化，导致解析出了错误的size数据
因而新增了一个应用于steam版的py文件，修改了itemoffset, itemsize, itemcrc的值，现在可以正确输出Asset Bundle
如果有条件的话建议测试一下这个调整是否适用于NS正式版